### PR TITLE
Add FastAPI-based relay server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.venv/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# CodeCodex
+# CodeCodex Relay Server
+
+This project provides a lightweight RESTful relay server implemented with [FastAPI](https://fastapi.tiangolo.com/). The service acts as a controlled proxy that forwards incoming HTTP requests to pre-configured upstream services.
+
+## Features
+
+- **Service allow-list** – Only upstream services defined in configuration can be targeted.
+- **Flexible payloads** – Supports JSON or raw body content as well as arbitrary headers and query parameters.
+- **Timeout controls** – Callers can specify a per-request timeout (capped at 60 seconds).
+- **Health and discovery endpoints** – Includes `/health` and `/services` routes for monitoring and configuration discovery.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10+
+- Recommended: a virtual environment (via `python -m venv .venv`)
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Running the Server
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The service will start on `http://127.0.0.1:8000` by default.
+
+### Configuration
+
+Upstream services are defined through the `RELAY_RELAY_SERVICES` environment variable (or `.env` file) as either JSON or comma-separated `name=url` pairs.
+
+Examples:
+
+```bash
+export RELAY_RELAY_SERVICES='{"httpbin": "https://httpbin.org"}'
+# or
+export RELAY_RELAY_SERVICES='httpbin=https://httpbin.org,service2=https://example.com'
+```
+
+### Example Request
+
+Relay a GET request to the `/uuid` endpoint on `https://httpbin.org`:
+
+```bash
+curl -X POST http://127.0.0.1:8000/relay \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service": "httpbin",
+    "path": "/uuid",
+    "method": "GET"
+  }'
+```
+
+Or use the convenience GET endpoint:
+
+```bash
+curl http://127.0.0.1:8000/relay/httpbin/uuid
+```
+
+## Development
+
+- Format and lint using your preferred tools (e.g., `ruff`, `black`).
+- Run the server locally via `uvicorn app.main:app --reload`.
+- Extend `app/schemas.py` if additional validation rules are required.
+
+## License
+
+This project is provided as-is for demonstration purposes.

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,61 @@
+"""Application configuration for the relay server."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    relay_services: Dict[str, str] = Field(
+        default_factory=lambda: {
+            "httpbin": "https://httpbin.org",
+        },
+        description=(
+            "Mapping of service identifiers to the upstream base URLs that the "
+            "relay server is allowed to proxy requests to."
+        ),
+    )
+
+    class Config:
+        env_prefix = "RELAY_"
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @validator("relay_services", pre=True)
+    def _normalize_services(cls, value: Dict[str, str]) -> Dict[str, str]:
+        if isinstance(value, str):
+            # Allow JSON-style strings or comma-separated "name=url" pairs
+            import json
+
+            try:
+                parsed = json.loads(value)
+                if isinstance(parsed, dict):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+            services: Dict[str, str] = {}
+            for item in value.split(","):
+                if not item:
+                    continue
+                name, _, url = item.partition("=")
+                if not name or not url:
+                    raise ValueError(
+                        "relay_services must be provided as JSON or 'name=url' pairs"
+                    )
+                services[name.strip()] = url.strip()
+            return services
+        return value
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()
+
+
+settings = get_settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,101 @@
+"""FastAPI application entry point for the relay server."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import httpx
+from fastapi import FastAPI, HTTPException
+
+from .config import settings
+from .schemas import HTTPMethod, RelayRequest, RelayResponse
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(
+    title="Relay API Server",
+    description=(
+        "A simple RESTful relay server that forwards requests to configured upstream "
+        "services with optional validation and timeout controls."
+    ),
+    version="0.1.0",
+)
+
+
+@app.get("/health", tags=["system"])
+async def health_check() -> Dict[str, str]:
+    """Health endpoint for monitoring."""
+
+    return {"status": "ok"}
+
+
+@app.get("/services", tags=["system"])
+async def list_services() -> Dict[str, Dict[str, str]]:
+    """Return the configured upstream services."""
+
+    return {"services": settings.relay_services}
+
+
+async def _perform_request(payload: RelayRequest) -> RelayResponse:
+    if payload.service not in settings.relay_services:
+        raise HTTPException(status_code=404, detail="Unknown service requested")
+
+    base_url = settings.relay_services[payload.service]
+    headers = payload.headers or {}
+
+    request_kwargs: Dict[str, Any] = {
+        "method": payload.method.value,
+        "url": payload.path,
+        "params": payload.query_params,
+        "headers": headers,
+    }
+
+    if payload.json_body is not None:
+        request_kwargs["json"] = payload.json_body
+    elif payload.raw_body is not None:
+        request_kwargs["content"] = payload.raw_body
+
+    timeout = httpx.Timeout(payload.timeout)
+
+    async with httpx.AsyncClient(base_url=base_url, timeout=timeout) as client:
+        try:
+            response = await client.request(**request_kwargs)
+        except httpx.TimeoutException as exc:
+            logger.warning("Timeout when calling %s%s", base_url, payload.path)
+            raise HTTPException(status_code=504, detail=str(exc)) from exc
+        except httpx.HTTPError as exc:
+            logger.exception("Error when calling upstream service")
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    parsed_body: Any = None
+    raw_text: str | None = None
+
+    try:
+        parsed_body = response.json()
+    except ValueError:
+        raw_text = response.text
+
+    return RelayResponse(
+        status_code=response.status_code,
+        headers=dict(response.headers),
+        body=parsed_body,
+        text=raw_text,
+        elapsed_ms=response.elapsed.total_seconds() * 1000,
+        url=response.url,
+    )
+
+
+@app.post("/relay", response_model=RelayResponse, tags=["relay"])
+async def relay(payload: RelayRequest) -> RelayResponse:
+    """Relay the incoming request to the configured upstream service."""
+
+    return await _perform_request(payload)
+
+
+@app.get("/relay/{service}/{path:path}", response_model=RelayResponse, tags=["relay"])
+async def relay_get(service: str, path: str) -> RelayResponse:
+    """Convenience GET endpoint using path parameters."""
+
+    payload = RelayRequest(service=service, path="/" + path, method=HTTPMethod.GET)
+    return await _perform_request(payload)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,84 @@
+"""Pydantic schemas for the relay API."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, HttpUrl, root_validator
+
+
+class HTTPMethod(str, Enum):
+    """Supported HTTP methods for relay requests."""
+
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+    HEAD = "HEAD"
+    OPTIONS = "OPTIONS"
+
+
+class RelayRequest(BaseModel):
+    """Incoming request payload instructing the relay server."""
+
+    service: str = Field(..., description="Service identifier configured on the server")
+    path: str = Field(
+        "/",
+        description="Path appended to the upstream service base URL",
+        regex=r"^/",
+    )
+    method: HTTPMethod = Field(HTTPMethod.GET, description="HTTP method to relay")
+    query_params: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Query parameters to include on the forwarded request",
+    )
+    headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Optional headers to include when relaying the request",
+    )
+    json_body: Optional[Any] = Field(
+        default=None,
+        description="JSON body content to send upstream (mutually exclusive with raw_body)",
+    )
+    raw_body: Optional[str] = Field(
+        default=None,
+        description="Raw string payload to send upstream when JSON is not desired",
+    )
+    timeout: float = Field(10.0, gt=0, le=60, description="Timeout in seconds for the upstream request")
+
+    class Config:
+        anystr_strip_whitespace = True
+
+    @root_validator
+    def _ensure_single_body(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        json_body = values.get("json_body")
+        raw_body = values.get("raw_body")
+        if json_body is not None and raw_body is not None:
+            raise ValueError("Only one of json_body or raw_body can be supplied")
+        return values
+
+
+class RelayResponse(BaseModel):
+    """Response payload returned to the caller after relaying the request."""
+
+    status_code: int = Field(..., description="HTTP status code from the upstream service")
+    headers: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Headers returned by the upstream service",
+    )
+    body: Optional[Any] = Field(
+        default=None,
+        description="Parsed JSON body returned by the upstream service, if available",
+    )
+    text: Optional[str] = Field(
+        default=None,
+        description="Raw text body returned by the upstream service when JSON parsing fails",
+    )
+    elapsed_ms: float = Field(
+        ...,
+        description="Time spent communicating with the upstream service, in milliseconds",
+    )
+    url: HttpUrl = Field(
+        ..., description="The full URL that was called on the upstream service"
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.2
+httpx==0.27.0
+uvicorn[standard]==0.29.0
+pydantic==1.10.14


### PR DESCRIPTION
## Summary
- implement a FastAPI application that relays requests to configured upstream services
- add configuration and schema modules to manage service allow-lists and payload validation
- document usage and list dependencies for running the relay server

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d742000b34832395e802ae71566618